### PR TITLE
Implement helper classes for creating Survey specs

### DIFF
--- a/docs/en-US/cmdlets/Register-AnsibleSurveySpec.md
+++ b/docs/en-US/cmdlets/Register-AnsibleSurveySpec.md
@@ -12,9 +12,15 @@ Register SurveySpecs.
 
 ## SYNTAX
 
+### Spec
 ```
 Register-AnsibleSurveySpec [-Template] <IResource> [-Name <String>] [-Description <String>]
  -Spec <SurveySpec[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Survey
+```
+Register-AnsibleSurveySpec [-Template] <IResource> -Survey <Survey> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,18 +35,29 @@ Implements following Rest API:
 ### Example 1
 ```powershell
 PS C:\> $jt = Get-AnsibleJobTemplate -Id 10
-PS C:\> Register-AnsibleSurveySpec $jt -Spec @{QuestionName="User name";Variable="user";Required=$true},@{QuestionName="Password";Variable="pass";Type="password";Required=$true}
+PS C:\> Register-AnsibleSurveySpec $jt -Spec @{Name="User name";Variable="user";Required=$true},@{Name="Password";Variable="pass";Type="password";Required=$true}
 ```
 
 ### Example 2
 ```powershell
 PS C:\> $jt = Get-AnsibleJobTemplate -Id 10
 PS C:\> $survey = $jt | Get-AnsibleSurveySpec
-PS C:\> $survey.Spec += @{ QuestionName="Select an animal"; Variable="animal"; Choices=@("cat","doc"); Type="multiplechoice" }
+PS C:\> $survey.Spec += @{ Name="Select an animal"; Variable="animal"; Choices=@("cat","doc"); Type="multiplechoice" }
 PS C:\> $jt | Register-AnsibleSurveySpec -Spec $survey.Spec
 ```
 
 Add multiple choice survey and re-register.
+
+### Example 3
+```powershell
+PS C:\> $jt = Get-AnsibleJobTemplate -Id 10
+PS C:\> $survey = New-Object Jagabata.Survey.Survey -Property @{ Name = "Survey Name"; Description = "" }
+PS C:\> $survey.Spec += New-Object Jagabata.Survey.TextSpec -ArgumentList "1.User","username" -Property @{ Required = $true; Default = "user1" }
+PS C:\> $survey.Spec += New-Object Jagabata.Survey.PasswordSpec -ArgumentList "2.Password","pass" -Property @{ Required = $true; }
+PS C:\> $jt | Register-AnsibleSurveySpec -Spec $survey
+```
+
+Register surveys created with Class.
 
 ## PARAMETERS
 
@@ -49,7 +66,7 @@ Optional description of the Survey.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: Spec
 Aliases:
 
 Required: False
@@ -64,7 +81,7 @@ Optional name of the Survey.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: Spec
 Aliases:
 
 Required: False
@@ -86,8 +103,8 @@ Array of `SurveySpec` objects.
   - `Float`: For survey questions expecting a decimal number.  
   - `MultipleChoice`: For survey questions where one option from a list is required.  
   - `MultiSelect`: For survey questions where multiple items from a presented list can be selected.  
-- `QuestionName`: The question to ask the user.  
-- `QuestionDescription`: Optional description of the question.  
+- `Name`: The question to ask the user.  
+- `Description`: Optional description of the question.  
 - `Variable`: Variable name to store the response. This is the variable to be used by the playbook. Variable names cannot contain spaces.  
 - `Required`: Whether or not an answer to the question is required.  
 - `Default`: Default value of the question  
@@ -97,7 +114,22 @@ Array of `SurveySpec` objects.
 
 ```yaml
 Type: SurveySpec[]
-Parameter Sets: (All)
+Parameter Sets: Spec
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Survey
+Object containing a `Spec` array, `Name` and `Description` which can create with `Jagabata.Survey.Survey` or `Jagabata.Resources.Survey`.
+
+```yaml
+Type: Survey
+Parameter Sets: Survey
 Aliases:
 
 Required: True

--- a/src/Jagabata/Cmdlets/LaunchJobCommandBase.cs
+++ b/src/Jagabata/Cmdlets/LaunchJobCommandBase.cs
@@ -148,7 +148,7 @@ public abstract class LaunchJobCommandBase : APICmdletBase
             _ => throw new ArgumentException($"Invalid Resource Type: {type}")
         };
 
-        var survey = GetResource<Survey>(surveyPath);
+        var survey = GetResource<Resources.Survey>(surveyPath);
         var extraVars = sendData.ContainsKey("extra_vars")
             ? Yaml.DeserializeToDict(sendData["extra_vars"] as string ?? "")
             : new Dictionary<string, object?>();

--- a/src/Jagabata/Cmdlets/LaunchJobCommandBase.cs
+++ b/src/Jagabata/Cmdlets/LaunchJobCommandBase.cs
@@ -171,10 +171,10 @@ public abstract class LaunchJobCommandBase : APICmdletBase
                 if (onlyRequired && !spec.Required)
                     continue;
 
-                var label = $"Survey {spec.QuestionName}";
+                var label = $"Survey {spec.Name}";
                 var key = $"extra_vars.{varName}";
                 var description = $"Variable: [{varName}]"
-                    + (string.IsNullOrEmpty(spec.QuestionDescription) ? "" : $", Description: {spec.QuestionDescription}");
+                    + (string.IsNullOrEmpty(spec.Description) ? "" : $", Description: {spec.Description}");
                 switch (spec.Type)
                 {
                     case SurveySpecType.Text:

--- a/src/Jagabata/Cmdlets/SurveyCommand.cs
+++ b/src/Jagabata/Cmdlets/SurveyCommand.cs
@@ -5,7 +5,7 @@ using System.Management.Automation;
 namespace Jagabata.Cmdlets
 {
     [Cmdlet(VerbsCommon.Get, "SurveySpec")]
-    [OutputType(typeof(Survey))]
+    [OutputType(typeof(Resources.Survey))]
     public class GetSurveySpecCommand : APICmdletBase
     {
         [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, Position = 0)]
@@ -23,7 +23,7 @@ namespace Jagabata.Cmdlets
                 ResourceType.WorkflowJobTemplate => $"{WorkflowJobTemplate.PATH}{Id}/survey_spec/",
                 _ => throw new ArgumentException($"Unkown Resource Type: {Type}")
             };
-            var survey = GetResource<Survey>(path);
+            var survey = GetResource<Resources.Survey>(path);
             WriteObject(survey);
         }
     }
@@ -58,11 +58,11 @@ namespace Jagabata.Cmdlets
                 ResourceType.WorkflowJobTemplate => $"{WorkflowJobTemplate.PATH}{Template.Id}/survey_spec/",
                 _ => throw new ArgumentException($"Invalid Resource Type: {Template.Type}")
             };
-            var sendData = new Survey() { Name = Name, Description = Description, Spec = Spec };
+            var sendData = new Resources.Survey() { Name = Name, Description = Description, Spec = Spec };
             var dataDescription = Json.Stringify(sendData, pretty: true);
             if (ShouldProcess(dataDescription, $"Register Survey to {Template.Type} [{Template.Id}]"))
             {
-                var apiResult = CreateResource<Survey>(path, sendData);
+                var apiResult = CreateResource<Resources.Survey>(path, sendData);
                 if (apiResult.Response.IsSuccessStatusCode)
                 {
                     WriteVerbose("Success");

--- a/src/Jagabata/Cmdlets/SurveyCommand.cs
+++ b/src/Jagabata/Cmdlets/SurveyCommand.cs
@@ -39,16 +39,19 @@ namespace Jagabata.Cmdlets
         ])]
         public IResource Template { get; set; } = new Resource(0, 0);
 
-        [Parameter()]
+        [Parameter(ParameterSetName = "Spec")]
         [AllowEmptyString]
         public string Name { get; set; } = string.Empty;
 
-        [Parameter()]
+        [Parameter(ParameterSetName = "Spec")]
         [AllowEmptyString]
         public string Description { get; set; } = string.Empty;
 
-        [Parameter(Mandatory = true)]
+        [Parameter(Mandatory = true, ParameterSetName = "Spec")]
         public SurveySpec[] Spec { get; set; } = [];
+
+        [Parameter(Mandatory = true, ParameterSetName = "Survey")]
+        public Resources.Survey? Survey { get; set; }
 
         protected override void ProcessRecord()
         {
@@ -58,7 +61,7 @@ namespace Jagabata.Cmdlets
                 ResourceType.WorkflowJobTemplate => $"{WorkflowJobTemplate.PATH}{Template.Id}/survey_spec/",
                 _ => throw new ArgumentException($"Invalid Resource Type: {Template.Type}")
             };
-            var sendData = new Resources.Survey() { Name = Name, Description = Description, Spec = Spec };
+            var sendData = Survey is not null ? Survey : new Resources.Survey() { Name = Name, Description = Description, Spec = Spec };
             var dataDescription = Json.Stringify(sendData, pretty: true);
             if (ShouldProcess(dataDescription, $"Register Survey to {Template.Type} [{Template.Id}]"))
             {

--- a/src/Jagabata/Resources/Survey.cs
+++ b/src/Jagabata/Resources/Survey.cs
@@ -27,8 +27,8 @@ namespace Jagabata.Resources
     [JsonConverter(typeof(SurveySpecConverter))]
     public class SurveySpec
     {
-        public string QuestionName { get; set; } = string.Empty;
-        public string QuestionDescription { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
         public SurveySpecType Type { get; set; }
         public bool Required { get; set; } = false;
         public string Variable { get; set; } = string.Empty;
@@ -40,7 +40,7 @@ namespace Jagabata.Resources
 
         public override string ToString()
         {
-            return $"{{ Name = {QuestionName}, Type = {Type}, Variable = {Variable}, Default = {Default} }}";
+            return $"{{ Name = {Name}, Type = {Type}, Variable = {Variable}, Default = {Default} }}";
         }
     }
 
@@ -114,10 +114,10 @@ namespace Jagabata.Resources
                         spec.NewQuestion = reader.GetBoolean();
                         break;
                     case "question_name":
-                        spec.QuestionName = reader.GetString() ?? "";
+                        spec.Name = reader.GetString() ?? "";
                         break;
                     case "question_description":
-                        spec.QuestionDescription = reader.GetString() ?? "";
+                        spec.Description = reader.GetString() ?? "";
                         break;
                 }
             }
@@ -127,8 +127,8 @@ namespace Jagabata.Resources
         public override void Write(Utf8JsonWriter writer, SurveySpec value, JsonSerializerOptions options)
         {
             writer.WriteStartObject();
-            writer.WriteString("question_name", value.QuestionName);
-            writer.WriteString("question_description", value.QuestionDescription);
+            writer.WriteString("question_name", value.Name);
+            writer.WriteString("question_description", value.Description);
             writer.WriteString("type", value.Type.ToString().ToLowerInvariant());
             writer.WriteBoolean("required", value.Required);
             writer.WriteString("variable", value.Variable);

--- a/src/Jagabata/Resources/Survey.cs
+++ b/src/Jagabata/Resources/Survey.cs
@@ -27,13 +27,29 @@ namespace Jagabata.Resources
     [JsonConverter(typeof(SurveySpecConverter))]
     public class SurveySpec
     {
+        public SurveySpec()
+        { }
+        public SurveySpec(SurveySpecType type)
+        {
+            Type = type;
+        }
+        public SurveySpec(SurveySpecType type, string variableName) : this(type)
+        {
+            Name = variableName;
+            Variable = variableName;
+        }
+        public SurveySpec(SurveySpecType type, string name, string variableName) : this(type)
+        {
+            Name = name;
+            Variable = variableName;
+        }
         public string Name { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
-        public SurveySpecType Type { get; set; }
+        public SurveySpecType Type { get; internal set; }
         public bool Required { get; set; } = false;
         public string Variable { get; set; } = string.Empty;
-        public object? Default { get; set; }
-        public object Choices { get; set; } = string.Empty;
+        public virtual object? Default { get; set; }
+        public virtual object Choices { get; set; } = string.Empty;
         public int Min { get; set; } = 0;
         public int Max { get; set; } = 1024;
         public bool NewQuestion { get; set; }

--- a/src/Jagabata/Survey/ChoiceSpec.cs
+++ b/src/Jagabata/Survey/ChoiceSpec.cs
@@ -1,0 +1,38 @@
+using Jagabata.Resources;
+
+namespace Jagabata.Survey;
+
+public class ChoiceSpec : SelectSpec
+{
+    public ChoiceSpec() : base(SurveySpecType.MultipleChoice)
+    { }
+    public ChoiceSpec(string name, string variableName) : base(SurveySpecType.MultipleChoice, name, variableName)
+    { }
+    public ChoiceSpec(string variableName): base(SurveySpecType.MultipleChoice, variableName)
+    { }
+    public override object? Default
+    {
+        get { return _default; }
+        set
+        {
+            if (value is null)
+            {
+                _default = null;
+            }
+            else
+            {
+                string val = $"{value}";
+                if (_choices.Any(item => item == val))
+                {
+                    _default = val;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"\"{val}\" is must be one of the Choices [{string.Join(", ", _choices.Select(x=>$"\"{x}\""))}]");
+                }
+            }
+        }
+    }
+    private string? _default = null;
+}
+

--- a/src/Jagabata/Survey/FloatSpec.cs
+++ b/src/Jagabata/Survey/FloatSpec.cs
@@ -1,0 +1,14 @@
+using Jagabata.Resources;
+
+namespace Jagabata.Survey;
+
+public sealed class FloatSpec : InputSpec<float>
+{
+    public FloatSpec() : base(SurveySpecType.Float)
+    { }
+    public FloatSpec(string name, string variableName) : base(SurveySpecType.Float, name, variableName)
+    { }
+    public FloatSpec(string variableName): base(SurveySpecType.Float, variableName)
+    { }
+}
+

--- a/src/Jagabata/Survey/InputSpec.cs
+++ b/src/Jagabata/Survey/InputSpec.cs
@@ -1,0 +1,33 @@
+using Jagabata.Resources;
+
+namespace Jagabata.Survey;
+
+public abstract class InputSpec<T> : SurveySpec
+{
+    public InputSpec(SurveySpecType type) : base(type)
+    { }
+    public InputSpec(SurveySpecType type, string name, string variableName) : base(type, name, variableName)
+    { }
+    public InputSpec(SurveySpecType type, string variableName): this(type, variableName, variableName)
+    { }
+    public sealed override object? Default
+    {
+        get { return DefaultValue; }
+        set
+        {
+            if (value is null)
+            {
+                DefaultValue = default(T);
+                return;
+            }
+            DefaultValue = (T)value;
+        }
+    }
+    protected T? DefaultValue = default(T);
+    public sealed override object Choices
+    {
+        get { return string.Empty; }
+        set { throw new InvalidOperationException(""); }
+    }
+}
+

--- a/src/Jagabata/Survey/IntegerSpec.cs
+++ b/src/Jagabata/Survey/IntegerSpec.cs
@@ -1,0 +1,14 @@
+using Jagabata.Resources;
+
+namespace Jagabata.Survey;
+
+public sealed class IntegerSpec : InputSpec<int>
+{
+    public IntegerSpec() : base(SurveySpecType.Integer)
+    { }
+    public IntegerSpec(string name, string variableName) : base(SurveySpecType.Integer, name, variableName)
+    { }
+    public IntegerSpec(string variableName): base(SurveySpecType.Integer, variableName)
+    { }
+}
+

--- a/src/Jagabata/Survey/MultiSelectSpec.cs
+++ b/src/Jagabata/Survey/MultiSelectSpec.cs
@@ -1,0 +1,62 @@
+using System.Collections;
+using Jagabata.Resources;
+
+namespace Jagabata.Survey;
+
+public class MultiSelectSpec : SelectSpec
+{
+    public MultiSelectSpec() : base(SurveySpecType.MultiSelect)
+    { }
+    public MultiSelectSpec(string name, string variableName) : base(SurveySpecType.MultiSelect, name, variableName)
+    { }
+    public MultiSelectSpec(string variableName): base(SurveySpecType.MultiSelect, variableName)
+    { }
+    public override object? Default
+    {
+        get => string.Join('\n', _defaults);
+        set
+        {
+            switch (value)
+            {
+                case null:
+                    _defaults = [];
+                    break;
+                case string str:
+                    _defaults = str.Split('\n');
+                    foreach (var item in _defaults)
+                    {
+                        if (!_choices.Any(c => c == item))
+                        {
+                            throw new InvalidDataException($"\"{item}\" is must be one of the Choices values [{string.Join(", ", _choices.Select(c => $"\"{c}\""))}]");
+                        }
+                    }
+                    break;
+                case IList list:
+                    var results = new List<string>();
+                    foreach (var item in list)
+                    {
+                        if (item is null)
+                        {
+                            continue;
+                        }
+
+                        string val = $"{item}";
+                        if (_choices.Any(c => c == val))
+                        {
+                            results.Add(val);
+                        }
+                        else
+                        {
+                            throw new InvalidDataException($"\"{val}\" is must be one of the Choices values [{string.Join(", ", _choices.Select(c => $"\"{c}\""))}]");
+                        }
+                    }
+                    _defaults = [.. results];
+                    break;
+                default:
+                    throw new InvalidCastException($"{nameof(value)} is must be string or IList: {value.GetType()}");
+            }
+        }
+    }
+    private string[] _defaults = [];
+}
+

--- a/src/Jagabata/Survey/PasswordSpec.cs
+++ b/src/Jagabata/Survey/PasswordSpec.cs
@@ -1,0 +1,14 @@
+using Jagabata.Resources;
+
+namespace Jagabata.Survey;
+
+public sealed class PasswordSpec : InputSpec<string>
+{
+    public PasswordSpec() : base(SurveySpecType.Password)
+    { }
+    public PasswordSpec(string name, string variableName) : base(SurveySpecType.Password, name, variableName)
+    { }
+    public PasswordSpec(string variableName): base(SurveySpecType.Password, variableName)
+    { }
+}
+

--- a/src/Jagabata/Survey/SelectSpec.cs
+++ b/src/Jagabata/Survey/SelectSpec.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using Jagabata.Resources;
+
+namespace Jagabata.Survey;
+
+public abstract class SelectSpec : SurveySpec
+{
+    public SelectSpec(SurveySpecType type) : base(type)
+    { }
+    public SelectSpec(SurveySpecType type, string name, string variableName) : base(type, name, variableName)
+    { }
+    public SelectSpec(SurveySpecType type, string variableName): this(type, variableName, variableName)
+    { }
+    public sealed override object Choices
+    {
+        get { return _choices; }
+        set
+        {
+            switch (value)
+            {
+                case null:
+                    _choices = [];
+                    break;
+                case string str:
+                    _choices = [str];
+                    break;
+                case IList list:
+                    var results = new List<string>();
+                    foreach (var item in list)
+                    {
+                        if (item is null) continue;
+                        results.Add($"{item}");
+                    }
+                    _choices = results.ToArray();
+                    break;
+                default:
+                    throw new InvalidCastException($"{nameof(value)} is must be string or IList: {value.GetType()}");
+            }
+        }
+    }
+    protected string[] _choices = [];
+}
+

--- a/src/Jagabata/Survey/Survey.cs
+++ b/src/Jagabata/Survey/Survey.cs
@@ -1,0 +1,9 @@
+namespace Jagabata.Survey;
+
+/// <summary>
+/// Alias to <see cref="Jagabata.Resources.Survey" />
+/// </summary>
+/// <seealso cref="Resources.Survey"/>
+public class Survey : Resources.Survey
+{
+}

--- a/src/Jagabata/Survey/TextSpec.cs
+++ b/src/Jagabata/Survey/TextSpec.cs
@@ -1,0 +1,14 @@
+using Jagabata.Resources;
+
+namespace Jagabata.Survey;
+
+public sealed class TextSpec : InputSpec<string>
+{
+    public TextSpec() : base(SurveySpecType.Text)
+    { }
+    public TextSpec(string name, string variableName) : base(SurveySpecType.Text, name, variableName)
+    { }
+    public TextSpec(string variableName): base(SurveySpecType.Text, variableName)
+    { }
+}
+

--- a/src/Jagabata/Survey/TextareaSpec.cs
+++ b/src/Jagabata/Survey/TextareaSpec.cs
@@ -1,0 +1,14 @@
+using Jagabata.Resources;
+
+namespace Jagabata.Survey;
+
+public sealed class TextareaSpec : InputSpec<string>
+{
+    public TextareaSpec() : base(SurveySpecType.Textarea)
+    { }
+    public TextareaSpec(string name, string variableName) : base(SurveySpecType.Textarea, name, variableName)
+    { }
+    public TextareaSpec(string variableName): base(SurveySpecType.Textarea, variableName)
+    { }
+}
+

--- a/src/formats.ps1xml
+++ b/src/formats.ps1xml
@@ -114,6 +114,68 @@
       </ListControl>
     </View>
     <View>
+      <Name>SurveySepec</Name>
+      <ViewSelectedBy>
+        <TypeName>Jagabata.Resources.SurveySpec</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader/><!-- Name -->
+          <TableColumnHeader/><!-- Description -->
+          <TableColumnHeader><!-- Type -->
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader><!-- Required -->
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader/><!-- Variable -->
+          <TableColumnHeader><!-- Default -->
+            <Label>Default</Label>
+          </TableColumnHeader>
+          <TableColumnHeader/><!-- Choices -->
+          <TableColumnHeader><!-- Min -->
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader><!-- Max -->
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Description</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Type</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Required</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Variable</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>if ($_.Type -eq "MultiSelect") { $_.Default -split "`n" } else { $_.Default }</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Choices</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Min</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Max</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
       <Name>UnifiedJobTemplate</Name>
       <ViewSelectedBy>
         <TypeName>Jagabata.Resources.JobTemplate</TypeName>


### PR DESCRIPTION
- Implement: in `Jagabata.Survey` namespace
  - `Survey` (alias to `Jagabata.Resources.Survey`)
  - `TextSpec`
  - `TextareaSpec`
  - `PasswordSpec`
  - `IntegerSpec`
  - `FloatSpec`
  - `ChoideSpec`
  - `MultiSelectSpec`
- Add `-Spec` parameter to `Register-SurveySpec` cmdlet