### PR TITLE
Implement Order by completer for Find cmdlets

### DIFF
--- a/src/Jagabata/Cmdlets/ActivityStreamCommand.cs
+++ b/src/Jagabata/Cmdlets/ActivityStreamCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -71,6 +72,7 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "timestamp", "operation", "changes", "object1", "object2", "action_node"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/AdHocCommandCommand.cs
+++ b/src/Jagabata/Cmdlets/AdHocCommandCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Collections;
 using System.Management.Automation;
@@ -39,6 +40,12 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "launch_type", "status", "execution_environment",
+                                   "failed", "started", "finished", "canceled_on", "elapsed", "job_explanation",
+                                   "execution_node", "controller_node", "work_unit_id", "job_type", "inventory", "limit",
+                                   "credential", "module_name", "module_args", "forks", "verbosity", "become_enabled",
+                                   "diff_mode", "hosts", "organization", "schedule", "created_by", "modified_by",
+                                   "instance_group", "labels"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
 

--- a/src/Jagabata/Cmdlets/ApplicationCommand.cs
+++ b/src/Jagabata/Cmdlets/ApplicationCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -38,6 +39,8 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "name", "description", "client_type", "redirect_uris",
+                                   "authorization_grant_type", "skip_authorization", "organization", "user"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/Completer/OrderByCompleter.cs
+++ b/src/Jagabata/Cmdlets/Completer/OrderByCompleter.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace Jagabata.Cmdlets.Completer;
+
+internal class OrderByCompleter : IArgumentCompleter
+{
+    public OrderByCompleter(params string[] keys)
+    {
+        Keys = keys;
+    }
+    public string[] Keys { get; init; }
+    public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName,
+                                                          string wordToComplete, CommandAst commandAst,
+                                                          IDictionary fakeBoundParameters)
+    {
+        var word = wordToComplete.StartsWith('!')
+                   ? wordToComplete[1..].ToLowerInvariant()
+                   : wordToComplete.ToLowerInvariant();
+        foreach (var key in Keys)
+        {
+            if (!key.StartsWith(word, StringComparison.InvariantCulture))
+            {
+                continue;
+            }
+
+            yield return new CompletionResult(key, key, CompletionResultType.Keyword, $"Order by {key} ascending");
+            var descendingProp = '!' + key;
+            yield return new CompletionResult(descendingProp, descendingProp, CompletionResultType.Keyword, $"Order by {key} descending");
+        }
+    }
+}

--- a/src/Jagabata/Cmdlets/Completer/OrderByCompletionAttribute.cs
+++ b/src/Jagabata/Cmdlets/Completer/OrderByCompletionAttribute.cs
@@ -1,0 +1,12 @@
+using System.Management.Automation;
+
+namespace Jagabata.Cmdlets.Completer;
+
+internal class OrderByCompletionAttribute : ArgumentCompleterAttribute, IArgumentCompleterFactory
+{
+    public string[] Keys { get; init; } = [];
+    public IArgumentCompleter Create()
+    {
+        return new OrderByCompleter(Keys);
+    }
+}

--- a/src/Jagabata/Cmdlets/CredentialCommand.cs
+++ b/src/Jagabata/Cmdlets/CredentialCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Collections;
 using System.Management.Automation;
@@ -64,6 +65,8 @@ namespace Jagabata.Cmdlets
         /// Only affected for an Organization
         /// </summary>
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "organization",
+                                   "credential_type", "managed", "created_by", "modified_by"])]
         public SwitchParameter Galaxy { get; set; }
 
         [Parameter()]

--- a/src/Jagabata/Cmdlets/CredentialInputSourceCommand.cs
+++ b/src/Jagabata/Cmdlets/CredentialInputSourceCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -29,6 +30,8 @@ namespace Jagabata.Cmdlets
         public ulong Credential { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "description", "input_field_name",
+                                   "metadata", "target_credential", "source_credential"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/CredentialTypeCommand.cs
+++ b/src/Jagabata/Cmdlets/CredentialTypeCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Collections;
 using System.Management.Automation;
@@ -29,6 +30,8 @@ namespace Jagabata.Cmdlets
         public CredentialTypeKind[]? Kind { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "kind", "namespace",
+                                   "managed", "inputs", "injectors", "created_by", "modified_by"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/ExecutionEnvironmentCommand.cs
+++ b/src/Jagabata/Cmdlets/ExecutionEnvironmentCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -28,6 +29,8 @@ namespace Jagabata.Cmdlets
         public ulong Organization { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "organization",
+                                   "image", "managed", "credential", "pull"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/GroupCommand.cs
+++ b/src/Jagabata/Cmdlets/GroupCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -60,6 +61,8 @@ namespace Jagabata.Cmdlets
         public SwitchParameter OnlyParnets { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "inventory", "variables",
+                                   "parents", "created_by", "modified_by", "children", "hosts"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/HostCommand.cs
+++ b/src/Jagabata/Cmdlets/HostCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -50,6 +51,9 @@ namespace Jagabata.Cmdlets
         public SwitchParameter OnlyChildren { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "inventory", "enabled",
+                                   "instance_id", "variables", "last_job", "last_job_host_summary",
+                                   "ansible_facts_modified", "groups", "created_by", "modified_by"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/HostMetricsCommand.cs
+++ b/src/Jagabata/Cmdlets/HostMetricsCommand.cs
@@ -1,3 +1,4 @@
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -24,6 +25,8 @@ namespace Jagabata.Cmdlets
     public class FindHostMetricCommand : FindCommandBase
     {
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "hostname", "first_automation", "last_automation", "last_deleted",
+                                   "automated_counter", "deleted_counter", "deleted", "used_in_inventories"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/InstanceCommand.cs
+++ b/src/Jagabata/Cmdlets/InstanceCommand.cs
@@ -1,3 +1,4 @@
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -27,6 +28,10 @@ namespace Jagabata.Cmdlets
         public ulong InstanceGroup { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "hostname", "uuid", "created", "modified", "last_seen", "health_check_started",
+                                   "last_health_check", "errors", "capacity_adjustment", "version", "capacity", "cpu",
+                                   "memory", "cpu_capacity", "mem_capacity", "enabled", "managed_by_policy", "node_type",
+                                   "node_state", "ip_address", "listener_port", "peers_from_control_nodes"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/InstanceGroupCommand.cs
+++ b/src/Jagabata/Cmdlets/InstanceGroupCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -49,6 +50,9 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "name", "created", "modified", "max_concurrent_jobs", "max_forks",
+                                   "is_container_group", "credential", "policy_instance_percentage",
+                                   "policy_instance_minimum", "policy_instance_list"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/InventoryCommand.cs
+++ b/src/Jagabata/Cmdlets/InventoryCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -45,6 +46,11 @@ namespace Jagabata.Cmdlets
         public InventoryKind Kind { get; set; } = InventoryKind.All;
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "organization", "kind",
+                                   "host_filter", "variables", "has_active_failures", "total_hosts",
+                                   "hosts_with_active_failures", "total_groups", "has_inventory_sources",
+                                   "total_inventory_sources", "inventory_sources_with_failures", "pending_deletion",
+                                   "prevent_instance_group_fallback", "created_by", "modified_by"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         public enum InventoryKind

--- a/src/Jagabata/Cmdlets/InventorySourceCommand.cs
+++ b/src/Jagabata/Cmdlets/InventorySourceCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -43,6 +44,11 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "source", "source_path",
+                                   "source_vars", "scm_branch", "enabled_var", "enabled_value", "host_filter", "overwrite",
+                                   "overwrite_vars", "timeout", "verbosity", "limit", "last_job_run", "last_job_failed",
+                                   "next_job_run", "status", "execution_environment", "inventory", "update_on_launch",
+                                   "update_cache_timeout", "source_project"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/InventoryUpdateCommand.cs
+++ b/src/Jagabata/Cmdlets/InventoryUpdateCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -36,6 +37,12 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "unified_job_template", "launch_type", "status", "execution_environment", "failed",
+                                   "started", "finished", "canceled_on", "elapsed", "job_explanation", "execution_node",
+                                   "controller_node", "work_unit_id", "source", "source_path", "source_vars", "scm_branch",
+                                   "enabled_var", "enabled_value", "enabled_value", "overwrite", "overwrite_vars",
+                                   "timeout", "verbosity", "limit", "inventory", "inventory_source", "license_error",
+                                   "org_host_limit_error", "source_project_update", "instance_group", "scm_revision"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/JobCommand.cs
+++ b/src/Jagabata/Cmdlets/JobCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -37,6 +38,15 @@ namespace Jagabata.Cmdlets
         public string[]? LaunchType { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "unified_job_template",
+                                   "launch_type", "status", "execution_environment", "failed", "started", "finished",
+                                   "canceled_on", "elapsed", "job_explanation", "execution_node", "controller_node",
+                                   "work_unit_id", "job_type", "inventory", "project", "playbook", "scm_branch", "forks",
+                                   "limit", "verbosity", "job_tags", "force_handlers", "skip_tags", "start_at_task",
+                                   "timeout", "use_fact_cache", "organization", "job_template", "allow_simultaneous",
+                                   "artifacts", "scm_revision", "instance_group", "diff_mode", "job_slice_number",
+                                   "job_slice_count", "webhook_service", "webhook_credential", "webhook_credential",
+                                   "schedule", "created_by", "modified_by", "labels"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
 

--- a/src/Jagabata/Cmdlets/JobEventCommand.cs
+++ b/src/Jagabata/Cmdlets/JobEventCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -37,6 +38,8 @@ namespace Jagabata.Cmdlets
         public SwitchParameter AdHocCommandEvent { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "event", "counter", "event_data", "failed", "changed",
+                                   "uuid", "stdout", "start_line", "end_line", "verbosity"])]
         public override string[] OrderBy { get; set; } = ["counter"];
 
         protected override void ProcessRecord()

--- a/src/Jagabata/Cmdlets/JobHostSummaryCommand.cs
+++ b/src/Jagabata/Cmdlets/JobHostSummaryCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -38,6 +39,9 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "job", "host", "constructed_host", "host_name",
+                                   "changed", "dark", "failures", "ok", "processed", "skipped", "failed",
+                                   "ignored", "rescued"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
         protected override void ProcessRecord()

--- a/src/Jagabata/Cmdlets/JobTemplateCommand.cs
+++ b/src/Jagabata/Cmdlets/JobTemplateCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Cmdlets.Utilities;
 using Jagabata.Resources;
 using System.Management.Automation;
@@ -48,6 +49,17 @@ namespace Jagabata.Cmdlets
         public string[]? Name { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "job_type", "inventory", "project",
+                                   "playbook", "scm_branch", "forks", "limit", "verbosity", "job_tags", "force_handlers",
+                                   "skip_tags", "start_at_task", "timeout", "use_fact_cache", "organization", "last_job_run",
+                                   "last_job_failed", "next_job_run", "status", "execution_environment", "ask_scm_branch_on_launch",
+                                   "ask_diff_mode_on_launch", "ask_variables_on_launch", "ask_limit_on_launch", "ask_tags_on_launch",
+                                   "ask_skip_tags_on_launch", "ask_job_type_on_launch", "ask_verbosity_on_launch",
+                                   "ask_inventory_on_launch", "ask_credential_on_launch", "ask_execution_environment_on_launch",
+                                   "ask_labels_on_launch", "ask_forks_on_launch", "ask_job_slice_count_on_launch",
+                                   "ask_timeout_on_launch", "ask_instance_groups_on_launch", "survey_enabled", "become_enabled",
+                                   "diff_mode", "allow_simultaneous", "custom_virtualenv", "job_slice_count", "webhook_service",
+                                   "webhook_credential", "prevent_instance_group_fallback"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/LabelCommand.cs
+++ b/src/Jagabata/Cmdlets/LabelCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -51,6 +52,7 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "organization"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/NotificationCommand.cs
+++ b/src/Jagabata/Cmdlets/NotificationCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -50,6 +51,8 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "notification_template", "error", "status",
+                                   "notifications_sent", "notification_type", "recipients", "subject", "body"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/NotificationTemplateCommand.cs
+++ b/src/Jagabata/Cmdlets/NotificationTemplateCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Collections;
 using System.Management.Automation;
@@ -30,6 +31,8 @@ namespace Jagabata.Cmdlets
         public ulong Organization { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "organization",
+                                   "notification_type", "messages"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()
@@ -66,6 +69,8 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "organization",
+                                   "notification_type", "messages"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()
@@ -118,6 +123,8 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "organization",
+                                   "notification_type", "messages"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()
@@ -174,6 +181,8 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "organization",
+                                   "notification_type", "messages"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()
@@ -219,6 +228,8 @@ namespace Jagabata.Cmdlets
         public ulong Id { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "organization",
+                                   "notification_type", "messages"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         [Parameter(Mandatory = true, ParameterSetName = "PipelineInput", ValueFromPipeline = true, Position = 0)]

--- a/src/Jagabata/Cmdlets/OrganizationCommand.cs
+++ b/src/Jagabata/Cmdlets/OrganizationCommand.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 
 namespace Jagabata.Cmdlets
@@ -35,6 +36,8 @@ namespace Jagabata.Cmdlets
         public string[]? Name { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description",
+                                   "max_hosts", "default_environment"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()
@@ -96,7 +99,7 @@ namespace Jagabata.Cmdlets
             }
         }
     }
-    
+
     [Cmdlet(VerbsData.Update, "Organization", SupportsShouldProcess = true)]
     [OutputType(typeof(Organization))]
     public class UpdateOrganizationCommand : UpdateCommandBase<Organization>

--- a/src/Jagabata/Cmdlets/ProjectCommand.cs
+++ b/src/Jagabata/Cmdlets/ProjectCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -42,6 +43,12 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "local_path", "scm_type",
+                                   "scm_url", "scm_branch", "scm_refspec", "scm_clean", "scm_track_submodules",
+                                   "scm_delete_on_update", "credential", "timeout", "scm_revision", "last_job_run",
+                                   "last_job_failed", "next_job_run", "status", "organization", "scm_update_on_launch",
+                                   "scm_update_cache_timeout", "allow_override", "default_environment",
+                                   "signature_validation_credential", "last_update_failed", "last_updated"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/ProjectUpdateCommand.cs
+++ b/src/Jagabata/Cmdlets/ProjectUpdateCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -32,6 +33,11 @@ namespace Jagabata.Cmdlets
         public string[]? Status { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "launch_type", "status",
+                                   "execution_environment", "failed", "started", "finished", "canceled_on", "elapsed",
+                                   "job_explanation", "execution_node", "work_unit_id", "local_path", "scm_type",
+                                   "scm_url", "scm_branch", "scm_refspec", "scm_clean", "scm_track_submodules",
+                                   "scm_delete_on_update", "credential", "timeout", "scm_revision", "project"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
 

--- a/src/Jagabata/Cmdlets/RoleCommand.cs
+++ b/src/Jagabata/Cmdlets/RoleCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -40,6 +41,8 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "name", "description", "parents", "parents", "content_type",
+                                   "ancestors", "descendents", "children"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()
@@ -96,6 +99,8 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "name", "description", "parents", "parents", "content_type",
+                                   "ancestors", "descendents", "children"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/ScheduleCommand.cs
+++ b/src/Jagabata/Cmdlets/ScheduleCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -46,6 +47,10 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["rrule", "id", "created", "modified", "name", "description", "extra_data",
+                                   "inventory", "execution_environment", "unified_job_template", "enabled",
+                                   "dtstart", "dtend", "next_run", "created_by", "modified_by", "credentials",
+                                   "instance_groups", "labels"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/SystemJobCommand.cs
+++ b/src/Jagabata/Cmdlets/SystemJobCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -29,6 +30,11 @@ namespace Jagabata.Cmdlets
         public string[]? Status { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "unified_job_template",
+                                   "launch_type", "status", "execution_environment", "failed", "started", "finished",
+                                   "canceled_on", "elapsed", "job_explanation", "execution_node", "work_unit_id",
+                                   "system_job_template", "job_type", "schedule", "notifications", "created_by",
+                                   "modified_by", "dependent_jobs", "labels", "instance_group"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
 

--- a/src/Jagabata/Cmdlets/SystemJobTemplateCommand.cs
+++ b/src/Jagabata/Cmdlets/SystemJobTemplateCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Collections;
 using System.Management.Automation;
@@ -27,6 +28,12 @@ namespace Jagabata.Cmdlets
     public class FindSystemJobTemplateCommand : FindCommandBase
     {
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "last_job_run",
+                                   "last_job_failed", "next_job_run", "status", "execution_environment",
+                                   "job_type", "notification_templates_error", "notification_templates_success",
+                                   "notification_templates_started", "unifiedjob_unified_jobs", "last_job",
+                                   "organization", "schedules", "jobs", "created_by", "credentials", "current_job",
+                                   "modified_by", "instance_groups", "labels", "next_schedule"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
 

--- a/src/Jagabata/Cmdlets/TeamCommand.cs
+++ b/src/Jagabata/Cmdlets/TeamCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -46,6 +47,8 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "organization",
+                                   "created_by", "modified_by"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/TokenCommand.cs
+++ b/src/Jagabata/Cmdlets/TokenCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -48,6 +49,8 @@ namespace Jagabata.Cmdlets
         public ETokenType TokenType { get; set; } = ETokenType.Both;
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "description", "user",
+                                   "application", "expires", "scope"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         public enum ETokenType

--- a/src/Jagabata/Cmdlets/UnifiedJobCommand.cs
+++ b/src/Jagabata/Cmdlets/UnifiedJobCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Cmdlets.Utilities;
 using Jagabata.Resources;
 using System.Collections.Specialized;
@@ -44,6 +45,11 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "unified_job_template",
+                                   "launch_type", "status", "execution_environment", "failed", "started", "finished",
+                                   "canceled_on", "elapsed", "job_explanation", "execution_node", "controller_node",
+                                   "work_unit_id", "notifications", "organization", "schedule", "created_by",
+                                   "modified_by", "credentials", "instance_group", "labels"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
         private IEnumerable<ResultSet> GetResultSet(string path,

--- a/src/Jagabata/Cmdlets/UnifiedJobTemplateCommand.cs
+++ b/src/Jagabata/Cmdlets/UnifiedJobTemplateCommand.cs
@@ -1,3 +1,4 @@
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Collections.Specialized;
 using System.Management.Automation;
@@ -9,6 +10,11 @@ namespace Jagabata.Cmdlets
     public class FindUnifiedJobTemplateCommand : FindCommandBase
     {
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "last_job_run", "last_job_failed",
+                                   "next_job_run", "status", "execution_environment", "notification_templates_error",
+                                   "notification_templates_success", "notification_templates_started", "last_job",
+                                   "organization", "schedules", "labels", "created_by", "modified_by", "credentials",
+                                   "instance_groups", "next_schedule"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         private IEnumerable<ResultSet> GetResultSet(string path,

--- a/src/Jagabata/Cmdlets/UserCommand.cs
+++ b/src/Jagabata/Cmdlets/UserCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Cmdlets.Utilities;
 using Jagabata.Resources;
 using System.Management.Automation;
@@ -66,6 +67,9 @@ namespace Jagabata.Cmdlets
         public string[]? Email { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "username", "first_name", "last_name", "email", "is_superuser", "last_login",
+                                   "enterprise_auth", "social_auth", "main_oauth2application", "activity_stream",
+                                   "roles", "profile"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()
@@ -133,6 +137,9 @@ namespace Jagabata.Cmdlets
         public IResource? Resource { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "username", "first_name", "last_name", "email", "is_superuser", "last_login",
+                                   "enterprise_auth", "social_auth", "main_oauth2application", "activity_stream",
+                                   "roles", "profile"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()
@@ -207,7 +214,7 @@ namespace Jagabata.Cmdlets
                 _user = Credential.UserName;
                 _password = Credential.Password;
             }
-            else 
+            else
             {
                 _user = UserName;
                 if (Password is not null)

--- a/src/Jagabata/Cmdlets/WorkflowApprovalCommand.cs
+++ b/src/Jagabata/Cmdlets/WorkflowApprovalCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 using System.Web;
@@ -30,6 +31,11 @@ namespace Jagabata.Cmdlets
         public JobStatus[]? Status { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "unified_job_template",
+                                   "launch_type", "status", "execution_environment", "failed", "started", "finished",
+                                   "canceled_on", "elapsed", "job_explanation", "work_unit_id", "timed_out",
+                                   "workflow_approval_template", "approved_or_denied_by", "schedule", "notifications",
+                                   "created_by", "modified_by", "instance_group", "organization", "labels"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/WorkflowJobCommand.cs
+++ b/src/Jagabata/Cmdlets/WorkflowJobCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -47,6 +48,13 @@ namespace Jagabata.Cmdlets
         public string[]? LaunchType { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "unified_job_template",
+                                   "launch_type", "status", "failed", "started", "finished", "canceled_on",
+                                   "elapsed", "job_explanation", "work_unit_id", "workflow_job_template",
+                                   "allow_simultaneous", "job_template", "is_sliced_job", "inventory",
+                                   "webhook_service", "webhook_credential", "webhook_guid", "notifications",
+                                   "unified_job_node", "workflow_job_template", "organization", "schedule",
+                                   "created_by", "modified_by", "instance_group", "labels"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/WorkflowJobNodeCommand.cs
+++ b/src/Jagabata/Cmdlets/WorkflowJobNodeCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Management.Automation;
 
@@ -36,6 +37,9 @@ namespace Jagabata.Cmdlets
         public WorkflowJobNodeLinkState Linked { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "extra_data", "inventory", "execution_environment",
+                                   "job", "workflow_job", "unified_job_template", "success_nodes", "failure_nodes",
+                                   "always_nodes", "all_parents_must_converge", "do_not_run", "identifier", "labels"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Jagabata/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Cmdlets.Utilities;
 using Jagabata.Resources;
 using System.Management.Automation;
@@ -32,6 +33,15 @@ namespace Jagabata.Cmdlets
         public ulong Organization { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "name", "description", "last_job_run",
+                                   "last_job_failed", "next_job_run", "status", "organization", "survey_enabled",
+                                   "allow_simultaneous", "ask_variables_on_launch", "inventory",
+                                   "ask_inventory_on_launch", "ask_scm_branch_on_launch", "ask_limit_on_launch",
+                                   "webhook_service", "webhook_credential", "ask_labels_on_launch",
+                                   "ask_skip_tags_on_launch", "ask_tags_on_launch", "notification_templates_error",
+                                   "notification_templates_success", "notification_templates_approvals",
+                                   "notification_templates_started", "inventory", "organization", "last_job",
+                                   "schedules", "created_by", "modified_by", "labels", "next_schedule"])]
         public override string[] OrderBy { get; set; } = ["id"];
 
         protected override void BeginProcessing()

--- a/src/Jagabata/Cmdlets/WorkflowJobTemplateNodeCommand.cs
+++ b/src/Jagabata/Cmdlets/WorkflowJobTemplateNodeCommand.cs
@@ -1,4 +1,5 @@
 using Jagabata.Cmdlets.ArgumentTransformation;
+using Jagabata.Cmdlets.Completer;
 using Jagabata.Resources;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
@@ -37,6 +38,9 @@ namespace Jagabata.Cmdlets
         public WorkflowJobNodeLinkState Linked { get; set; }
 
         [Parameter()]
+        [OrderByCompletion(Keys = ["id", "created", "modified", "extra_data", "inventory", "execution_environment",
+                                   "workflow_job_template", "unified_job_template", "success_nodes", "failure_nodes",
+                                   "always_nodes", "all_parents_must_converge", "identifier", "instance_groups", "labels"])]
         public override string[] OrderBy { get; set; } = ["!id"];
 
         protected override void BeginProcessing()


### PR DESCRIPTION
Implement `-OrderBy` parameter's completer

- [x] FindActivityStream
- [x] FindAdHocCommandJob
- [x] FindApplication
- [x] FindCredential
- [x] FindCredentialInputSource
- [x] FindCredentialType
- [x] FindExecutionEnvironment
- [x] FindGroup
- [x] FindHost
- [x] FindHostMetric
- [x] FindInstance
- [x] FindInstanceGroup
- [x] FindInventory
- [x] FindInventorySource
- [x] FindInventoryUpdateJob
- [x] FindJob
- [x] FindJobEvent
- [x] FindJobHostSummary
- [x] FindJobTemplate
- [x] FindLabel
- [x] FindNotification
- [x] FindNotificationTemplate
- [x] FindNotificationTemplateForApproval
- [x] FindNotificationTemplateForError
- [x] FindNotificationTemplateForStarted
- [x] FindNotificationTemplateForSuccess
- [x] FindOrganization
- [x] FindProject
- [x] FindProjectUpdateJob
- [x] FindRole
- [x] FindObjectRole
- [x] FindSchedule
- [x] FindSystemJob
- [x] FindSystemJobTemplate
- [x] FindTeam
- [x] FindToken
- [x] FindUnifiedJob
- [x] FindUnifiedJobTemplate
- [x] FindUser
- [x] FindAccessList
- [x] FindWorkflowApprovalRequest
- [x] FindWorkflowJob
- [x] FindWorkflowJobNode
- [x] FindWorkflowJobTemplate
- [x] FindWorkflowJobTemplateNode
