### PR TITLE
:bug: fix RelatedResourceConverter

### DIFF
--- a/src/Jagabata/Json.cs
+++ b/src/Jagabata/Json.cs
@@ -173,7 +173,25 @@ namespace Jagabata
 
             public override void Write(Utf8JsonWriter writer, RelatedDictionary value, JsonSerializerOptions options)
             {
-                JsonSerializer.Serialize(writer, value, options);
+                writer.WriteStartObject();
+                foreach (var kv in value)
+                {
+                    writer.WritePropertyName(kv.Key);
+                    if (kv.Value is IList list)
+                    {
+                        writer.WriteStartArray();
+                        foreach (var item in list)
+                        {
+                            writer.WriteStringValue($"{item}");
+                        }
+                        writer.WriteEndArray();
+                    }
+                    else
+                    {
+                        writer.WriteStringValue($"{kv.Value}");
+                    }
+                }
+                writer.WriteEndObject();
             }
         }
         /// <summary>


### PR DESCRIPTION
Error at `Jagabata.Json+RelatedResourceConverter.Write()` and abort the PowerShell process when try to serialize a resource.
```
Stack overflow.
Repeat 21539 times:
--------------------------------
   at System.Text.Json.JsonSerializer.Serialize[[System.__Canon, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.Text.Json.Utf8JsonWriter, System.__Canon, System.Text.Json.JsonSerializerOptions)
   at Jagabata.Json+RelatedResourceConverter.Write(System.Text.Json.Utf8JsonWriter, Jagabata.Resources.RelatedDictionary, System.Text.Json.JsonSerializerOptions)
   at System.Text.Json.Serialization.JsonConverter`1[[System.__Canon, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].TryWrite(System.Text.Json.Utf8JsonWriter, System.__Canon ByRef, System.Text.Json.JsonSerializerOptions, System.Text.Json.WriteStack ByRef)
   at System.Text.Json.Serialization.JsonConverter`1[[System.__Canon, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].WriteCore(System.Text.Json.Utf8JsonWriter, System.__Canon ByRef, System.Text.Json.JsonSerializerOptions, System.Text.Json.WriteStack ByRef)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1[[System.__Canon, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].Serialize(System.Text.Json.Utf8JsonWriter, System.__Canon ByRef, System.Object)
--------------------------------

```