### PR TITLE
Refactor AdHocCommand launcher

### DIFF
--- a/docs/en-US/cmdlets/Invoke-AnsibleAdHocCommand.md
+++ b/docs/en-US/cmdlets/Invoke-AnsibleAdHocCommand.md
@@ -12,28 +12,8 @@ Invoke (launch) an AdHocCommand and wait until the job is finished.
 
 ## SYNTAX
 
-### Host
 ```
-Invoke-AnsibleAdHocCommand [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Host] <Host> [-ModuleName] <String>
- [[-ModuleArgs] <String>] [-Credential] <UInt64> [-Check] [<CommonParameters>]
-```
-
-### Group
-```
-Invoke-AnsibleAdHocCommand [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Group] <Group> [-ModuleName] <String>
- [[-ModuleArgs] <String>] [-Credential] <UInt64> [-Check] [<CommonParameters>]
-```
-
-### Inventory
-```
-Invoke-AnsibleAdHocCommand [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Inventory] <Inventory>
- [-ModuleName] <String> [[-ModuleArgs] <String>] [-Credential] <UInt64> [-Limit <String>] [-Check]
- [<CommonParameters>]
-```
-
-### InventoryId
-```
-Invoke-AnsibleAdHocCommand [-IntervalSeconds <Int32>] [-SuppressJobLog] [-InventoryId] <UInt64>
+Invoke-AnsibleAdHocCommand [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Target] <IResource>
  [-ModuleName] <String> [[-ModuleArgs] <String>] [-Credential] <UInt64> [-Limit <String>] [-Check]
  [<CommonParameters>]
 ```
@@ -101,36 +81,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Group
-Group to be executed.
-
-```yaml
-Type: Group
-Parameter Sets: Group
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -Host
-Host to be executed.
-
-```yaml
-Type: Host
-Parameter Sets: Host
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
 ### -IntervalSeconds
 Interval to confirm job completion (seconds).
 Default is 5 seconds.
@@ -147,42 +97,12 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Inventory
-Inventory to be executed.
-
-```yaml
-Type: Inventory
-Parameter Sets: Inventory
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -InventoryId
-Inventory ID to be executed.
-
-```yaml
-Type: UInt64
-Parameter Sets: InventoryId
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
 ### -Limit
 Further limit selected hosts to an additional pattern.
 
 ```yaml
 Type: String
-Parameter Sets: Inventory, InventoryId
+Parameter Sets: (All)
 Aliases:
 
 Required: False
@@ -254,22 +174,43 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Target
+Remote target resource to be executed.
+
+The resource is accepted following types:  
+- `Inventory`  
+- `Group`  
+- `Host`
+
+> [!TIP]  
+> Can specify the resource as string like `Group:1` (Format: `{Type}:{Id}`).
+> And also accept objects have `type` and `id` properties.  
+>
+> For example:  
+>  - `-Target (Get-AnsibleGroup -Id 1)`  
+>  - `-Target @{ type = "group"; id = 1 }`  
+>  - `-Target group:1`
+
+```yaml
+Type: IResource
+Parameter Sets: (All)
+Aliases: remote, r
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### Jagabata.Resources.Host
-Host object to be executed.
-
-### Jagabata.Resources.Group
-Group object to be executed.
-
-### Jagabata.Resources.Inventory
-Inventory object to be executed.
-
-### System.UInt64
-Inventory ID to be executed.
+### Jagabata.Resources.IResource
+Remote target resource to be executed.
+See: `-Target` parameter.
 
 ## OUTPUTS
 

--- a/docs/en-US/cmdlets/Start-AnsibleAdHocCommand.md
+++ b/docs/en-US/cmdlets/Start-AnsibleAdHocCommand.md
@@ -12,27 +12,8 @@ Invoke (launch) an AdHocCommand.
 
 ## SYNTAX
 
-### Host
 ```
-Start-AnsibleAdHocCommand [-Host] <Host> [-ModuleName] <String> [[-ModuleArgs] <String>] [-Credential] <UInt64>
- [-Check] [<CommonParameters>]
-```
-
-### Group
-```
-Start-AnsibleAdHocCommand [-Group] <Group> [-ModuleName] <String> [[-ModuleArgs] <String>]
- [-Credential] <UInt64> [-Check] [<CommonParameters>]
-```
-
-### Inventory
-```
-Start-AnsibleAdHocCommand [-Inventory] <Inventory> [-ModuleName] <String> [[-ModuleArgs] <String>]
- [-Credential] <UInt64> [-Limit <String>] [-Check] [<CommonParameters>]
-```
-
-### InventoryId
-```
-Start-AnsibleAdHocCommand [-InventoryId] <UInt64> [-ModuleName] <String> [[-ModuleArgs] <String>]
+Start-AnsibleAdHocCommand [-Target] <IResource> [-ModuleName] <String> [[-ModuleArgs] <String>]
  [-Credential] <UInt64> [-Limit <String>] [-Check] [<CommonParameters>]
 ```
 
@@ -92,72 +73,12 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Group
-Group to be executed.
-
-```yaml
-Type: Group
-Parameter Sets: Group
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -Host
-Host to be executed.
-
-```yaml
-Type: Host
-Parameter Sets: Host
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -Inventory
-Inventory to be executed.
-
-```yaml
-Type: Inventory
-Parameter Sets: Inventory
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -InventoryId
-Inventory ID to be executed.
-
-```yaml
-Type: UInt64
-Parameter Sets: InventoryId
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
 ### -Limit
 Further limit selected hosts to an additional pattern.
 
 ```yaml
 Type: String
-Parameter Sets: Inventory, InventoryId
+Parameter Sets: (All)
 Aliases:
 
 Required: False
@@ -201,22 +122,43 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Target
+Remote target resource to be executed.
+
+The resource is accepted following types:  
+- `Inventory`  
+- `Group`  
+- `Host`
+
+> [!TIP]  
+> Can specify the resource as string like `Group:1` (Format: `{Type}:{Id}`).
+> And also accept objects have `type` and `id` properties.  
+>
+> For example:  
+>  - `-Target (Get-AnsibleGroup -Id 1)`  
+>  - `-Target @{ type = "group"; id = 1 }`  
+>  - `-Target group:1`
+
+```yaml
+Type: IResource
+Parameter Sets: (All)
+Aliases: remote, r
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### Jagabata.Resources.Host
-Host object to be executed.
-
-### Jagabata.Resources.Group
-Group object to be executed.
-
-### Jagabata.Resources.Inventory
-Inventory object to be executed.
-
-### System.UInt64
-Inventory ID to be executed.
+### Jagabata.Resources.IResource
+Remote target resource to be executed.
+See: `-Target` parameter.
 
 ## OUTPUTS
 

--- a/src/Jagabata/Cmdlets/AdHocCommandCommand.cs
+++ b/src/Jagabata/Cmdlets/AdHocCommandCommand.cs
@@ -75,17 +75,14 @@ namespace Jagabata.Cmdlets
 
     public abstract class LaunchAdHocCommandBase : LaunchJobCommandBase
     {
-        [Parameter(Mandatory = true, ParameterSetName = "Host", ValueFromPipeline = true, Position = 0)]
-        public Host? Host { get; set; }
-
-        [Parameter(Mandatory = true, ParameterSetName = "Group", ValueFromPipeline = true, Position = 0)]
-        public Group? Group { get; set; }
-
-        [Parameter(Mandatory = true, ParameterSetName = "Inventory", ValueFromPipeline = true, Position = 0)]
-        public Inventory? Inventory { get; set; }
-
-        [Parameter(Mandatory = true, ParameterSetName = "InventoryId", ValueFromPipeline = true, Position = 0)]
-        public ulong InventoryId { get; set; }
+        /// <summary>
+        /// Execution target, <c>Inventory</c>, <c>Group</c> or <c>Host</c>
+        /// </summary>
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
+        [ResourceTransformation(ResourceType.Host, ResourceType.Host, ResourceType.Inventory)]
+        [ResourceCompletions(ResourceType.Host, ResourceType.Host, ResourceType.Inventory)]
+        [Alias("remote", "r")]
+        public IResource Target { get; set; } = new Resource(0, 0);
 
         [Parameter(Mandatory = true, Position = 1)]
         public string ModuleName { get; set; } = string.Empty;
@@ -97,8 +94,10 @@ namespace Jagabata.Cmdlets
         [Parameter(Mandatory = true, Position = 3)]
         public ulong Credential { get; set; }
 
-        [Parameter(ParameterSetName = "Inventory")]
-        [Parameter(ParameterSetName = "InventoryId")]
+        /// <summary>
+        /// Affected only when the target is <c>Inventory</c>
+        /// </summary>
+        [Parameter()]
         public string Limit { get; set; } = string.Empty;
 
         [Parameter()]
@@ -114,30 +113,20 @@ namespace Jagabata.Cmdlets
             {
                 SendData.Add("job_type", "check");
             }
-            if (!string.IsNullOrEmpty(Limit))
+            if (Target.Type == ResourceType.Inventory && !string.IsNullOrEmpty(Limit))
             {
                 SendData.Add("limit", Limit);
             }
         }
         private string GetPath()
         {
-            if (InventoryId > 0)
+            return Target.Type switch
             {
-                return $"{Inventory.PATH}{InventoryId}/ad_hoc_commands/";
-            }
-            else if (Inventory is not null)
-            {
-                return $"{Inventory.PATH}{Inventory.Id}/ad_hoc_commands/";
-            }
-            else if (Host is not null)
-            {
-                return $"{Host.PATH}{Host.Id}/ad_hoc_commands/";
-            }
-            else if (Group is not null)
-            {
-                return $"{Group.PATH}{Group.Id}/ad_hoc_commands/";
-            }
-            throw new ArgumentException();
+                ResourceType.Inventory => $"{Inventory.PATH}{Target.Id}/ad_hoc_commands/",
+                ResourceType.Host => $"{Host.PATH}{Target.Id}/ad_hoc_commands/",
+                ResourceType.Group => $"{Group.PATH}{Target.Id}/ad_hoc_commands/",
+                _ => throw new ArgumentException(),
+            };
         }
         protected AdHocCommand? Launch()
         {

--- a/src/Jagabata/Cmdlets/AdHocCommandCommand.cs
+++ b/src/Jagabata/Cmdlets/AdHocCommandCommand.cs
@@ -92,6 +92,8 @@ namespace Jagabata.Cmdlets
         public string ModuleArgs { get; set; } = string.Empty;
 
         [Parameter(Mandatory = true, Position = 3)]
+        [ResourceIdTransformation(ResourceType.Credential)]
+        [ResourceCompletions(ResourceCompleteType.Id, ResourceType.Credential)]
         public ulong Credential { get; set; }
 
         /// <summary>

--- a/src/Jagabata/Cmdlets/AdHocCommandCommand.cs
+++ b/src/Jagabata/Cmdlets/AdHocCommandCommand.cs
@@ -85,6 +85,11 @@ namespace Jagabata.Cmdlets
         public IResource Target { get; set; } = new Resource(0, 0);
 
         [Parameter(Mandatory = true, Position = 1)]
+        [ArgumentCompletions(
+            "command", "shell", "yum", "apt", "apt_key", "apt_repository", "apt_rpm", "service",
+            "group", "user", "mount", "ping", "selinux", "setup", "win_ping", "win_service",
+            "win_updates", "win_group", "win_user"
+        )]
         public string ModuleName { get; set; } = string.Empty;
 
         [Parameter(Position = 2)]


### PR DESCRIPTION
**BREAKING CHANGE** command syntax for `Invoke-AdHocCommand` and `Start-AdHocCommand` 

- Remove `-Host`, `-Group`, `-Inventory` and `-InventoryId` parameters
- Unified to `-Target` parameter instead.

And
- Add parameter completions for `-Target`, `-Credentiall` and `-ModuleName`